### PR TITLE
Fix to broken persons query

### DIFF
--- a/lib/routes/persons.js
+++ b/lib/routes/persons.js
@@ -14,8 +14,8 @@ module.exports = Router()
 
     Person
       .find(req.query)
-      .gte('age', minAge)
-      .lte('age', maxAge)
+      .gte('age', Number(minAge))
+      .lte('age', Number(maxAge))
       .limit(Number(perPage))
       .skip((Number(page) - 1) * Number(perPage))
       .select({ fullName: false, swisId: false })

--- a/lib/scripts/handle-detention.test.js
+++ b/lib/scripts/handle-detention.test.js
@@ -29,18 +29,17 @@ describe('booking model', () => {
     const person = await Person.create(scrape);
     const courtCase = await CourtCase.create(scrape.case);
     const detention = await handleDetention(scrape, bookingState, person._id, courtCase);
-    const prepare = (obj) => JSON.parse(JSON.stringify(obj));
-    return expect (prepare(detention)).toEqual({
-      bookingStates: [bookingState._id.toString()],
-      caseStates: [courtCase._id.toString()],
-      currentCaseState: courtCase._id.toString(),
-      _id: detention._id.toString(),
+    return expect (detention.toObject()).toEqual({
+      bookingStates: [bookingState._id],
+      caseStates: [courtCase._id],
+      currentCaseState: courtCase._id,
+      _id: detention._id,
       bookingNumber: '1489454',
-      bookingDate: expect.any(String),
-      person: person.id.toString(),
+      bookingDate: expect.any(Date),
+      person: person._id,
       arrestingAgency: 'MCSO Transports',
       __v: expect.any(Number),
-      currentBookingState: bookingState._id.toString()
+      currentBookingState: bookingState._id
     });
   });
 

--- a/lib/scripts/handle-detention.test.js
+++ b/lib/scripts/handle-detention.test.js
@@ -29,17 +29,18 @@ describe('booking model', () => {
     const person = await Person.create(scrape);
     const courtCase = await CourtCase.create(scrape.case);
     const detention = await handleDetention(scrape, bookingState, person._id, courtCase);
-    return expect (detention.toObject()).toEqual({
-      bookingStates: [bookingState.id],
-      caseStates: [courtCase.id],
-      currentCaseState: courtCase.id,
-      _id: detention._id,
+    const prepare = (obj) => JSON.parse(JSON.stringify(obj));
+    return expect (prepare(detention)).toEqual({
+      bookingStates: [bookingState._id.toString()],
+      caseStates: [courtCase._id.toString()],
+      currentCaseState: courtCase._id.toString(),
+      _id: detention._id.toString(),
       bookingNumber: '1489454',
-      bookingDate: expect.any(Date),
-      person: person.id,
+      bookingDate: expect.any(String),
+      person: person.id.toString(),
       arrestingAgency: 'MCSO Transports',
       __v: expect.any(Number),
-      currentBookingState: bookingState.id
+      currentBookingState: bookingState._id.toString()
     });
   });
 

--- a/lib/scripts/scrape-html.js
+++ b/lib/scripts/scrape-html.js
@@ -41,10 +41,8 @@ const scrapeHTML = (html) => {
       };
       caseInfo.charges.push(charge);
     });
-
     let recent = findRecentCase(caseNumbers);
-    let caseNumber = caseInfo.courtCaseNumber;
-
+    let caseNumber = caseInfo.caseNumber;
     if(sliceCaseNumber(caseNumber) === recent){
       cases.push(caseInfo);
     }

--- a/lib/scripts/seed.js
+++ b/lib/scripts/seed.js
@@ -24,7 +24,7 @@ const seedDatabase = async() => {
     }
     let courtCase;
     if(scrapeObject.case) {
-      courtCase = await CourtCase.findOne({ caseNumber: scrapeObject.case.courtCaseNumber });
+      courtCase = await CourtCase.findOne({ caseNumber: scrapeObject.case.caseNumber });
       if(!courtCase) {
         courtCase = await CourtCase.create(scrapeObject.case);
       }


### PR DESCRIPTION
So this bug was there for a long time, but it only showed up when "Infinity" was changed to 100 for the max age in the front end. The problem is that we were never turning the maxAge (or minAge) from a string to a number.